### PR TITLE
Fix issue in AtomicLong where single slot value was read

### DIFF
--- a/peers/src/main/java/gov/nasa/jpf/vm/JPF_java_util_concurrent_atomic_AtomicLong.java
+++ b/peers/src/main/java/gov/nasa/jpf/vm/JPF_java_util_concurrent_atomic_AtomicLong.java
@@ -58,14 +58,14 @@ public class JPF_java_util_concurrent_atomic_AtomicLong extends NativePeer {
 
   @MJI
   public long getAndAdd__J__J (MJIEnv env, int objRef, long delta) {
-    long value = env.getIntField(objRef, "value");
+    long value = env.getLongField(objRef, "value");
     env.setLongField(objRef, "value", value + delta);
     return value;
   }
   
   @MJI
   public long incrementAndGet____J (MJIEnv env, int objRef) {
-    long value = env.getIntField(objRef, "value");
+    long value = env.getLongField(objRef, "value");
     value++;
     env.setLongField(objRef, "value", value);
     return value;
@@ -73,7 +73,7 @@ public class JPF_java_util_concurrent_atomic_AtomicLong extends NativePeer {
   
   @MJI
   public long decrementAndGet____J (MJIEnv env, int objRef) {
-    long value = env.getIntField(objRef, "value");
+    long value = env.getLongField(objRef, "value");
     value--;
     env.setLongField(objRef, "value", value);
     return value;
@@ -81,7 +81,7 @@ public class JPF_java_util_concurrent_atomic_AtomicLong extends NativePeer {
   
   @MJI
   public long addAndGet__J__J (MJIEnv env, int objRef, long delta) {
-    long value = env.getIntField(objRef, "value");
+    long value = env.getLongField(objRef, "value");
     value += delta;
     env.setLongField(objRef, "value", value);
     return value;


### PR DESCRIPTION
There is some "copy&paste-driven" errors in jpf-core.

This pull reqest make jpf to not crash when working with AtomicLong primitives.

For example, try this:

```
public static void main(String[] args) {
    AtomicLong al = new AtomicLong(0);
    al.incrementAndGet();
}
```
